### PR TITLE
Inverter ordem dos botões de confirmação/cancelamento de compra

### DIFF
--- a/components/confirmation/Confirmation.js
+++ b/components/confirmation/Confirmation.js
@@ -62,14 +62,14 @@ export default class Confirmation extends Component {
         </View>
         <View>
           <Button
-            type="outline"
-            title="Cancelar"
-            onPress={ () => this.props.navigation.popToTop() }
+            title="Confirmar"
+            onPress={this.handleConfirm}
           />
 
           <Button
-            title="Confirmar"
-            onPress={this.handleConfirm}
+            type="outline"
+            title="Cancelar"
+            onPress={ () => this.props.navigation.popToTop() }
           />
         </View>
       </View>


### PR DESCRIPTION
## :alien: Hi hi :alien: 

In this PR we just change the position of buttons `Cancelar` <=> `Confirmar`...

### Changes imgs:

![WhatsApp Image 2019-09-16 at 22 39 09](https://user-images.githubusercontent.com/17733336/65004477-e5b3ac00-d8d2-11e9-9dd0-9eba53806693.jpeg)
